### PR TITLE
Fix case when lvlid is not initialised

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,3 +44,6 @@ Release
 # Jetbrains generated files
 /.idea/
 /cmake-*/
+
+# Build directory(ies)
+**/build/

--- a/src/maprenderer.cpp
+++ b/src/maprenderer.cpp
@@ -73,8 +73,8 @@ void MapRenderer::update() {
         return;
     }
     bool changed = session_.update(d2rProcess_.seed(), d2rProcess_.difficulty());
-    uint32_t levelId;
-    if (changed || (levelId = d2rProcess_.levelId()) != currLevelId_) {
+    uint32_t levelId = d2rProcess_.levelId();
+    if (changed || levelId != currLevelId_) {
         textStrings_.clear();
         lines_.clear();
         currLevelId_ = levelId;


### PR DESCRIPTION
If `changed` yield `true`, then `levelId` will not be set, thus resulting in exception later on