### PR TITLE
Add a config option for delay between rendering actions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,3 +47,4 @@ Release
 
 # Build directory(ies)
 **/build/
+/src/version_generated

--- a/bin/D2RMH.ini
+++ b/bin/D2RMH.ini
@@ -19,6 +19,11 @@ fps = -1
 ; 0-show map layer when in-game map is off
 ; 1-show map layer when in-game map is on
 ; 2-show map layer always
+render_delay = 50
+; value in milliseconds
+; the delay in rendering the next map update 
+; will help with GPU usage. Increase this if you notice framerate or GPU usage issue
+; set to 0 to disable (i.e. no delay in map update)
 show = 0
 ; hide map layer when certain panels are opened, 0x7F=all panels
 ;  0x01-inventory panel

--- a/src/cfg.cpp
+++ b/src/cfg.cpp
@@ -72,6 +72,7 @@ void loadCfg(const std::string &filename) {
         case 1:
             if (false) {}
             LOADVALN(fps, fps)
+            LOADVALN(render_delay, renderDelay)
             LOADVALN(show, show)
             LOADVALN(panel_mask, panelMask)
             LOADVALN(full_line, fullLine)

--- a/src/cfg.h
+++ b/src/cfg.h
@@ -19,6 +19,7 @@ struct Cfg {
     std::string language = "enUS";
 
     int fps = -1;
+    int renderDelay = 50; // in milliseconds
     int show = 0;
     uint32_t panelMask = 0xFF;
     int fullLine = 0;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -68,6 +68,9 @@ int WINAPI WinMain(HINSTANCE hinstance, HINSTANCE hPrevInstance, LPSTR lpCmdLine
         renderer.begin();
         map.render();
         renderer.end();
+        if (cfg->renderDelay > 0) {
+            Sleep(cfg->renderDelay);
+        }
     }
     return 0;
 }


### PR DESCRIPTION
This seems to be helping my GPU usage significantly in certain game scenarios (30%+ usage -> 5%) . The existing "fps" option does not seem to work when set to > 0.