### PR TITLE
fix should not checking portal during loading screen

### DIFF
--- a/bin/plugins/town_portal_check.lua
+++ b/bin/plugins/town_portal_check.lua
@@ -6,9 +6,9 @@ local town_portal_check = function()
         return
     end
 
-    local skill = get_skill(220)
-    if not skill or skill.quantity < 3 then
-        text:add("\x0BWARNING! Town portal scrolls quantity low", 1500, 0)
+    local portal_book = get_skill(220)
+    if portal_book.quantity < 3 then
+        text:add(string.format("\x0BWARNING! Town portal scrolls quantity low: %d", portal_book.quantity), 1500, 0)
     end
 end
 register_plugin(1000, town_portal_check)

--- a/bin/plugins/town_portal_check.lua
+++ b/bin/plugins/town_portal_check.lua
@@ -1,6 +1,11 @@
 local text = create_text_list("default")
 
 local town_portal_check = function()
+    -- game fully loaded?
+    if not get_skill(0) then
+        return
+    end
+
     local skill = get_skill(220)
     if not skill or skill.quantity < 3 then
         text:add("\x0BWARNING! Town portal scrolls quantity low", 1500, 0)


### PR DESCRIPTION
The message shouldn't show when a new game is just created and during loading.